### PR TITLE
Update 01-blending-in.md

### DIFF
--- a/01-blending-in.md
+++ b/01-blending-in.md
@@ -347,7 +347,7 @@ export const ThemeContext = createContext<ThemeContextType>({
 });
 ```
 
-2. Create the `useThemeProvider` hook. This will be used in one of our more top level `_layout.tsx` files just like any other provider with some type of global state.
+2. Create the `useThemeProvider` hook in the `src/utils` directory. This will be used in one of our more top level `_layout.tsx` files just like any other provider with some type of global state.
 
 This way the entire application will have access to the current theme value stored in the context.
 


### PR DESCRIPTION
I added a note for the hook to go in the `utils` directory. Without it, I initially was unsure where the directions were suggesting the file go.

I could see it being unnecessary or undesirable because 1. intermediate developers will more quickly know where "hooks" typically go and 2. I could see the ambiguity supporting learning by providing an opportunity for reflection and questions if the learner is confused.